### PR TITLE
[PF-83] Add new filter data types to schema

### DIFF
--- a/docs/petriflow.schema.xsd
+++ b/docs/petriflow.schema.xsd
@@ -245,6 +245,11 @@
   </xs:complexType>
   <!-- ===== RESTRICTIONS ===== -->
   <xs:simpleType name="data_type">
+    <xs:annotation>
+      <xs:documentation>
+        Type "filter" was removed. Use one of: caseFilter, taskFilter or processFilter
+      </xs:documentation>
+    </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="number"/>
       <xs:enumeration value="text"/>
@@ -263,7 +268,9 @@
       <xs:enumeration value="button"/>
       <xs:enumeration value="taskRef"/>
       <xs:enumeration value="caseRef"/>
-      <xs:enumeration value="filter"/>
+      <xs:enumeration value="caseFilter"/>
+      <xs:enumeration value="taskFilter"/>
+      <xs:enumeration value="processFilter"/>
       <xs:enumeration value="i18n"/>
     </xs:restriction>
   </xs:simpleType>

--- a/docs/petriflow.schema.xsd
+++ b/docs/petriflow.schema.xsd
@@ -99,8 +99,9 @@
       <xs:element type="transactionRef" name="transactionRef" minOccurs="0"/>
       <xs:element type="roleRef" name="roleRef" maxOccurs="unbounded" minOccurs="0"/>
       <xs:choice minOccurs="0">
-        <xs:element type="userRef" name="usersRef" maxOccurs="unbounded"/>
-        <xs:element type="userRef" name="userRef" maxOccurs="unbounded"/>
+        <!-- deprecated --> <xs:element type="actorRef" name="usersRef" maxOccurs="unbounded"/>
+        <!-- deprecated --> <xs:element type="actorRef" name="userRef" maxOccurs="unbounded"/>
+        <xs:element type="actorRef" name="actorRef" maxOccurs="unbounded"/>
       </xs:choice>
       <xs:element type="assignedUser" name="assignedUser" minOccurs="0"/>
       <xs:element type="dataRef" name="dataRef" maxOccurs="unbounded" minOccurs="0"/>
@@ -217,8 +218,9 @@
       <xs:element type="i18nStringTypeWithExpression" name="caseName" minOccurs="0"/>
       <xs:element type="caseRoleRef" name="roleRef" maxOccurs="unbounded" minOccurs="0"/>
       <xs:choice minOccurs="0">
-        <xs:element type="caseUserRef" name="usersRef" maxOccurs="unbounded"/>
-        <xs:element type="caseUserRef" name="userRef" maxOccurs="unbounded"/>
+        <!-- deprecated --> <xs:element type="caseActorRef" name="usersRef" maxOccurs="unbounded"/>
+        <!-- deprecated --> <xs:element type="caseActorRef" name="userRef" maxOccurs="unbounded"/>
+        <xs:element type="caseActorRef" name="actorRef" maxOccurs="unbounded"/>
       </xs:choice>
       <xs:element type="processEvents" name="processEvents" minOccurs="0"/>
       <xs:element type="caseEvents" name="caseEvents" minOccurs="0"/>
@@ -247,7 +249,10 @@
   <xs:simpleType name="data_type">
     <xs:annotation>
       <xs:documentation>
-        Type "filter" was removed. Use one of: caseFilter, taskFilter or processFilter
+        Deprecated attributes:
+        - filter: use caseFilter/taskFilter/processFilter
+        - user: use actor
+        - userList: use actorList
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -262,12 +267,15 @@
       <xs:enumeration value="date"/>
       <xs:enumeration value="file"/>
       <xs:enumeration value="fileList"/>
-      <xs:enumeration value="user"/>
-      <xs:enumeration value="userList"/>
+      <!-- deprecated --> <xs:enumeration value="user"/>
+      <xs:enumeration value="actor"/>
+      <!-- deprecated --> <xs:enumeration value="userList"/>
+      <xs:enumeration value="actorList"/>
       <xs:enumeration value="dateTime"/>
       <xs:enumeration value="button"/>
       <xs:enumeration value="taskRef"/>
       <xs:enumeration value="caseRef"/>
+      <!-- deprecated --> <xs:enumeration value="filter"/>
       <xs:enumeration value="caseFilter"/>
       <xs:enumeration value="taskFilter"/>
       <xs:enumeration value="processFilter"/>
@@ -482,7 +490,7 @@
       <xs:extension base="permissionRef"/>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="userRef">
+  <xs:complexType name="actorRef">
     <xs:complexContent>
       <xs:extension base="permissionRef"/>
     </xs:complexContent>
@@ -498,7 +506,7 @@
       <xs:extension base="casePermissionRef"/>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="caseUserRef">
+  <xs:complexType name="caseActorRef">
     <xs:complexContent>
       <xs:extension base="casePermissionRef"/>
     </xs:complexContent>

--- a/docs/v1.0.8/petriflow.schema.xsd
+++ b/docs/v1.0.8/petriflow.schema.xsd
@@ -99,9 +99,8 @@
       <xs:element type="transactionRef" name="transactionRef" minOccurs="0"/>
       <xs:element type="roleRef" name="roleRef" maxOccurs="unbounded" minOccurs="0"/>
       <xs:choice minOccurs="0">
-        <!-- deprecated --> <xs:element type="actorRef" name="usersRef" maxOccurs="unbounded"/>
-        <!-- deprecated --> <xs:element type="actorRef" name="userRef" maxOccurs="unbounded"/>
-        <xs:element type="actorRef" name="actorRef" maxOccurs="unbounded"/>
+        <xs:element type="userRef" name="usersRef" maxOccurs="unbounded"/>
+        <xs:element type="userRef" name="userRef" maxOccurs="unbounded"/>
       </xs:choice>
       <xs:element type="assignedUser" name="assignedUser" minOccurs="0"/>
       <xs:element type="dataRef" name="dataRef" maxOccurs="unbounded" minOccurs="0"/>
@@ -218,9 +217,8 @@
       <xs:element type="i18nStringTypeWithExpression" name="caseName" minOccurs="0"/>
       <xs:element type="caseRoleRef" name="roleRef" maxOccurs="unbounded" minOccurs="0"/>
       <xs:choice minOccurs="0">
-        <!-- deprecated --> <xs:element type="caseActorRef" name="usersRef" maxOccurs="unbounded"/>
-        <!-- deprecated --> <xs:element type="caseActorRef" name="userRef" maxOccurs="unbounded"/>
-        <xs:element type="caseActorRef" name="actorRef" maxOccurs="unbounded"/>
+        <xs:element type="caseUserRef" name="usersRef" maxOccurs="unbounded"/>
+        <xs:element type="caseUserRef" name="userRef" maxOccurs="unbounded"/>
       </xs:choice>
       <xs:element type="processEvents" name="processEvents" minOccurs="0"/>
       <xs:element type="caseEvents" name="caseEvents" minOccurs="0"/>
@@ -247,14 +245,6 @@
   </xs:complexType>
   <!-- ===== RESTRICTIONS ===== -->
   <xs:simpleType name="data_type">
-    <xs:annotation>
-      <xs:documentation>
-        Deprecated attributes:<br/>
-        - filter: use caseFilter/taskFilter/processFilter<br/>
-        - user: use actor<br/>
-        - userList: use actorList
-      </xs:documentation>
-    </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="number"/>
       <xs:enumeration value="text"/>
@@ -267,18 +257,13 @@
       <xs:enumeration value="date"/>
       <xs:enumeration value="file"/>
       <xs:enumeration value="fileList"/>
-      <!-- deprecated --> <xs:enumeration value="user"/>
-      <xs:enumeration value="actor"/>
-      <!-- deprecated --> <xs:enumeration value="userList"/>
-      <xs:enumeration value="actorList"/>
+      <xs:enumeration value="user"/>
+      <xs:enumeration value="userList"/>
       <xs:enumeration value="dateTime"/>
       <xs:enumeration value="button"/>
       <xs:enumeration value="taskRef"/>
       <xs:enumeration value="caseRef"/>
-      <!-- deprecated --> <xs:enumeration value="filter"/>
-      <xs:enumeration value="caseFilter"/>
-      <xs:enumeration value="taskFilter"/>
-      <xs:enumeration value="processFilter"/>
+      <xs:enumeration value="filter"/>
       <xs:enumeration value="i18n"/>
     </xs:restriction>
   </xs:simpleType>
@@ -490,7 +475,7 @@
       <xs:extension base="permissionRef"/>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="actorRef">
+  <xs:complexType name="userRef">
     <xs:complexContent>
       <xs:extension base="permissionRef"/>
     </xs:complexContent>
@@ -506,7 +491,7 @@
       <xs:extension base="casePermissionRef"/>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="caseActorRef">
+  <xs:complexType name="caseUserRef">
     <xs:complexContent>
       <xs:extension base="casePermissionRef"/>
     </xs:complexContent>


### PR DESCRIPTION
Added new filter data types: `caseFilter`, `taskFilter`, `processFilter`. 
Marked data type `filter` as deprecated
Updated docs